### PR TITLE
Fix SetSearchType

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/Models/Search.cs
+++ b/src/Our.Umbraco.FullTextSearch/Models/Search.cs
@@ -44,7 +44,7 @@ namespace Our.Umbraco.FullTextSearch.Models
 
         public Search SetSearchType(SearchType searchType)
         {
-            SearchType = SearchType;
+            SearchType = searchType;
             return this;
         }
 


### PR DESCRIPTION
This fixes SetSearchType setting SearchType to its current value rather than the supplied parameter.