### PR TITLE
Fix #61

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
@@ -124,9 +124,10 @@ namespace Our.Umbraco.FullTextSearch.Services
                     query.Append($" AND ({rootNodeGroup})");
                 }
 
-                if (_search.AllowedContentTypes.Any())
+                var allowedContentTypes = _search.AllowedContentTypes.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
+                if (allowedContentTypes.Any())
                 {
-                    var contentTypeGroup = string.Join(" OR ", _search.AllowedContentTypes.Select(x =>
+                    var contentTypeGroup = string.Join(" OR ", allowedContentTypes.Select(x =>
                         $"__NodeTypeAlias:{x}"));
                     query.Append($" AND ({contentTypeGroup})");
                 }


### PR DESCRIPTION
Fix #61 

We remove empty or null `AllowedContentTypes` in `SearchService` so we don't have to trust that the `Search` is created with valid content type strings.