### PR TITLE
Fix relative links to developers guide

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,5 +1,5 @@
-[v1.x Developers Guide](docs/developers-guide-v1.md)
+[v1.x Developers Guide](developers-guide-v1.md)
 The guide for v1 (the Umbraco 8 version)
 
-[v2.x Developers Guide](docs/developers-guide-v2.md)
+[v2.x Developers Guide](developers-guide-v2.md)
 The guide for v2 (the Umbraco 9 / net core version)


### PR DESCRIPTION
Links were broken because the `developers-guide.md` is now in the same folder as the `v1` and `v2` developer guides.