### PR TITLE
Include descendants on reindexing

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/App_Plugins/FullTextSearch/scripts/fulltextsearch.resource.js
+++ b/src/Our.Umbraco.FullTextSearch/App_Plugins/FullTextSearch/scripts/fulltextsearch.resource.js
@@ -20,7 +20,7 @@
                 }
 
                 if (nodeIds != "*" && includeDescendants) {
-                    nodeIds + "&includeDescendants=true";
+                    nodeIds += "&includeDescendants=true";
                 }
 
                 var url = Umbraco.Sys.ServerVariables.umbracoSettings.umbracoPath + "/backoffice/FullTextSearch/Index/ReindexNodes?nodeIds=" + nodeIds;


### PR DESCRIPTION
Hi, there are two issues with reindexing selected nodes with descendants, causing "Include descendants" not working at all.

1. in fulltextsearch.resource.js, there is missing equals sign here:
`nodeIds + "&includeDescendants=true";`
2. in IndexControlles.cs and its ReIndexNodes method, I believe index.IndexItems method should be called with ids of descendants, not just parent node. And those descendants should by get by specifying culture, because without it Umbraco returns descendants only for one culture. It could be done by iterating node.Cultures.

I am addressing 1.x version, but first issue seems to be in 2.x as well.