### PR TITLE
#82 added configuration option for highligting pattern

### DIFF
--- a/src/Our.Umbraco.FullTextSearch.Tests/Helpers/HighlighterShould.cs
+++ b/src/Our.Umbraco.FullTextSearch.Tests/Helpers/HighlighterShould.cs
@@ -1,0 +1,24 @@
+﻿using Our.Umbraco.FullTextSearch.Helpers;
+
+namespace Our.Umbraco.FullTextSearch.Tests.Helpers;
+
+public class HighlighterShould
+{
+    [Test]
+    public void Highlight_Exact_Matches()
+    {
+        var test = Highlighter.FindSnippet("This token should be highlighted, but not al tokens will be. Just that token in the beginning.", "token", 200, "<b>{0}</b>");
+
+        Assert.That(test, Is.EqualTo("This <b>token</b> should be highlighted, but not al tokens will be. Just that <b>token</b> in the beginning"));
+
+    }
+
+    [Test]
+    public void FindSnippet_And_Truncate()
+    {
+        var test = Highlighter.FindSnippet("This token should be highlighted, but not al tokens will be. Just that token in the beginning.", "token", 30, "<b>{0}</b>");
+
+        Assert.That(test, Is.EqualTo(" Just that <b>token</b> in the beginn"));
+
+    }
+}

--- a/src/Our.Umbraco.FullTextSearch.Tests/Our.Umbraco.FullTextSearch.Tests.csproj
+++ b/src/Our.Umbraco.FullTextSearch.Tests/Our.Umbraco.FullTextSearch.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Our.Umbraco.FullTextSearch\Our.Umbraco.FullTextSearch.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Our.Umbraco.FullTextSearch.Tests/Usings.cs
+++ b/src/Our.Umbraco.FullTextSearch.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/src/Our.Umbraco.FullTextSearch.sln
+++ b/src/Our.Umbraco.FullTextSearch.sln
@@ -18,7 +18,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.FullTextSearch.Testsite", "Our.Umbraco.FullTextSearch.Testsite\Our.Umbraco.FullTextSearch.Testsite.csproj", "{FD95D644-6C96-4731-A940-17AE8B784EBF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Our.Umbraco.FullTextSearch.Testsite", "Our.Umbraco.FullTextSearch.Testsite\Our.Umbraco.FullTextSearch.Testsite.csproj", "{FD95D644-6C96-4731-A940-17AE8B784EBF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.FullTextSearch.Tests", "Our.Umbraco.FullTextSearch.Tests\Our.Umbraco.FullTextSearch.Tests.csproj", "{31AFB56C-912D-480B-BD4F-F7FB0A7AC5C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +36,10 @@ Global
 		{FD95D644-6C96-4731-A940-17AE8B784EBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD95D644-6C96-4731-A940-17AE8B784EBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD95D644-6C96-4731-A940-17AE8B784EBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31AFB56C-912D-480B-BD4F-F7FB0A7AC5C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31AFB56C-912D-480B-BD4F-F7FB0A7AC5C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31AFB56C-912D-480B-BD4F-F7FB0A7AC5C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31AFB56C-912D-480B-BD4F-F7FB0A7AC5C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Our.Umbraco.FullTextSearch/Assembly.cs
+++ b/src/Our.Umbraco.FullTextSearch/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Our.Umbraco.FullTextSearch.Tests")]

--- a/src/Our.Umbraco.FullTextSearch/Helpers/Highlighter.cs
+++ b/src/Our.Umbraco.FullTextSearch/Helpers/Highlighter.cs
@@ -14,7 +14,7 @@ namespace Our.Umbraco.FullTextSearch.Helpers
             public int Offset;
         }
 
-        internal static string FindSnippet(string text, string query, int maxLength, string highlightBefore = "", string highlightAfter = "")
+        internal static string FindSnippet(string text, string query, int maxLength, string highlightPattern = "{0}")
         {
             if (maxLength < 0)
             {
@@ -52,34 +52,29 @@ namespace Our.Umbraco.FullTextSearch.Helpers
                     sb.Add(".");
                 }
                 previous = offset;
-                sb.Add(Highlight(sentence, words, highlightBefore, highlightAfter));
+                sb.Add(Highlight(sentence, words, highlightPattern));
             }
             return string.Join(".", sb);
         }
 
-        internal static string Highlight(string sentence, ILookup<string, string> words, string highlightBefore, string highlightAfter)
+        internal static string Highlight(string sentence, ILookup<string, string> words, string highlightPattern)
         {
             var sb = new List<string>();
-            var ff = true;
+
             foreach (var word in sentence.Split(' '))
             {
                 var token = word.ToLower();
-                if (ff && words.Contains(token))
+                if (words.Contains(token))
                 {
-                    sb.Add(highlightBefore);
-                    ff = !ff;
+                    sb.Add(string.Format(highlightPattern, word));
                 }
-                if (!ff && !string.IsNullOrWhiteSpace(token) && !words.Contains(token))
+                else
                 {
-                    sb.Add(highlightAfter);
-                    ff = !ff;
+                    sb.Add(word);
                 }
-                sb.Add(word);
+
             }
-            if (!ff)
-            {
-                sb.Add(highlightAfter);
-            }
+
             return string.Join(" ", sb);
         }
 

--- a/src/Our.Umbraco.FullTextSearch/Options/FullTextSearchOptions.cs
+++ b/src/Our.Umbraco.FullTextSearch/Options/FullTextSearchOptions.cs
@@ -21,5 +21,11 @@ namespace Our.Umbraco.FullTextSearch.Options
         public string FullTextContentField { get; set; } = "FullTextContent";
         [JsonProperty("fullTextPathField")]
         public string FullTextPathField { get; set; } = "FullTextPath";
+
+        /// <summary>
+        /// Pattern to use for highlighting text in search result html. Example: &lt;b&gt;{0}&lt;/b&gt;
+        /// </summary>
+        [JsonProperty("highlightPattern")]
+        public string HighlightPattern { get; set; } = "<b>{0}</b>";
     }
 }

--- a/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
@@ -363,7 +363,7 @@ namespace Our.Umbraco.FullTextSearch.Services
             string summary;
             if (!input.IsNullOrWhiteSpace() && (input.Length > _search.SummaryLength || _search.HighlightSearchTerms))
             {
-                summary = Highlighter.FindSnippet(input, string.Join(" ", _search.SearchTermSplit), _search.SummaryLength, _search.HighlightSearchTerms ? "<b>" : "", _search.HighlightSearchTerms ? "</b>" : "");
+                summary = Highlighter.FindSnippet(input, string.Join(" ", _search.SearchTermSplit), _search.SummaryLength, _search.HighlightSearchTerms ? _options.HighlightPattern : "{0}");
 
                 if (!string.IsNullOrEmpty(summary))
                     return summary;


### PR DESCRIPTION
Hi!

This adds a new configuration option for the pattern to use when highlighting tokens in the search result. Uses string.Format-pattern like `<b>{0}</b>` to make it possible to configure the html-element to use for highlighting.

Some things to note:
* Since I have another PR where I made some significant changes to the documentation I did not want to add more changes and create a merge-mess. I could create a new PR when things are merged (if they are = ).

