### PR TITLE
#98 Proposal for fix for issue with notification handlers

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/NotificationHandlers/UpdateCacheOnPublish.cs
+++ b/src/Our.Umbraco.FullTextSearch/NotificationHandlers/UpdateCacheOnPublish.cs
@@ -18,7 +18,7 @@ using Umbraco.Extensions;
 namespace Our.Umbraco.FullTextSearch.NotificationHandlers
 {
 
-    public class UpdateCacheOnPublish : INotificationAsyncHandler<ContentCacheRefresherNotification>
+    public class UpdateCacheOnPublish : INotificationHandler<ContentCacheRefresherNotification>
     {
         private FullTextSearchOptions _options;
         private ILogger<UpdateCacheOnPublish> _logger;
@@ -42,8 +42,9 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
 
         }
 
-        public async Task HandleAsync(ContentCacheRefresherNotification notification, CancellationToken cancellationToken)
+        public void Handle(ContentCacheRefresherNotification notification)
         {
+        
             if (notification.MessageType != MessageType.RefreshByPayload)
                 return;
 
@@ -63,7 +64,7 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
             {
                 if (payload.ChangeTypes.HasType(TreeChangeTypes.Remove))
                 {
-                    await _cacheService.DeleteFromCache(payload.Id);
+                    Task.WaitAll(_cacheService.DeleteFromCache(payload.Id));
                 }
                 else if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshAll))
                 {
@@ -71,7 +72,7 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
                 }
                 else // RefreshNode or RefreshBranch (maybe trashed)
                 {
-                    await _cacheService.AddToCache(payload.Id);
+                    Task.WaitAll(_cacheService.AddToCache(payload.Id));
 
                     // branch
                     if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshBranch))
@@ -87,7 +88,7 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
 
                             foreach (var descendant in descendants)
                             {
-                                await _cacheService.AddToCache(descendant.Id);
+                                Task.WaitAll(_cacheService.AddToCache(descendant.Id));
                             }
                         }
                     }
@@ -95,5 +96,6 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
             }
         }
 
+     
     }
 }

--- a/src/Our.Umbraco.FullTextSearch/ServicesConfiguration.cs
+++ b/src/Our.Umbraco.FullTextSearch/ServicesConfiguration.cs
@@ -10,6 +10,7 @@ using System;
 using System.Net.Http;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Infrastructure.Search;
 using Umbraco.Extensions;
 
 namespace Our.Umbraco.FullTextSearch
@@ -34,10 +35,10 @@ namespace Our.Umbraco.FullTextSearch
 
             builder
                 .AddNotificationHandler<UmbracoApplicationStartingNotification, ExecuteMigrations>()
-                .AddNotificationAsyncHandler<ContentCacheRefresherNotification, UpdateCacheOnPublish>()
                 .AddNotificationHandler<ServerVariablesParsingNotification, AddFullTextSearchToServerVariables>()
-                .AddNotificationHandler<UmbracoApplicationStartingNotification, AddFullTextItemsToIndex>();
-
+                .AddNotificationHandler<UmbracoApplicationStartingNotification, AddFullTextItemsToIndex>()
+                .AddNotificationHandlerBefore<ContentCacheRefresherNotification,ContentIndexingNotificationHandler,UpdateCacheOnPublish>();
+            
             return builder;
         }
 
@@ -53,4 +54,5 @@ namespace Our.Umbraco.FullTextSearch
             return builder;
         }
     }
+    
 }

--- a/src/Our.Umbraco.FullTextSearch/UmbracoBuilderExtensions.cs
+++ b/src/Our.Umbraco.FullTextSearch/UmbracoBuilderExtensions.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Our.Umbraco.FullTextSearch;
+
+internal static class UmbracoBuilderExtensions
+{
+    /// <summary>
+    /// Registers a notification handler that will be executed before another handler that was already registered.
+    /// This method must be called after the other handler has already been registered.
+    /// </summary>
+    /// <typeparam name="TNotification">The type of notification.</typeparam>
+    /// <typeparam name="TBeforeNotificationHandler">The other type of the notification handler that must run after the newly added</typeparam>
+    /// <typeparam name="TNotificationHandler">The type of notification handler.</typeparam>
+    /// <returns>The <see cref="IUmbracoBuilder"/>.</returns>
+    public static IUmbracoBuilder AddNotificationHandlerBefore<TNotification, TBeforeNotificationHandler, TNotificationHandler>(this IUmbracoBuilder builder)
+        where TNotificationHandler : INotificationHandler<TNotification>
+        where TNotification : INotification
+        where TBeforeNotificationHandler : INotificationHandler<TNotification>
+    {
+
+        var descriptor = new UniqueServiceDescriptor(typeof(INotificationHandler<TNotification>), typeof(TBeforeNotificationHandler), ServiceLifetime.Transient);
+
+        bool shouldReInsertBeforeHandler = false;
+
+        if (builder.Services.Contains(descriptor))
+        {
+            builder.Services.Remove(descriptor);
+            shouldReInsertBeforeHandler = true;
+        }
+
+        builder.AddNotificationHandler<TNotification, TNotificationHandler>();
+
+        // Make sure that TBeforeNotificationHandler is inserted after TNotificationHandler
+        // so that it runs after TNotificationHandler
+        if (shouldReInsertBeforeHandler)
+        {
+            builder.Services.Add(descriptor);
+        }
+
+        return builder;
+    }
+}


### PR DESCRIPTION
Hi!

Details about the underlying problem can be found here: https://github.com/skttl/umbraco-fulltextsearch8/issues/98

This PR will:

* Revert our the `UpdateCacheOnPublish` notification handler to be synchronous
* Keep the async nature of the `IPageRenderer` and `CacheService` by using `Task.WaitAll()` in `UpdateCacheOnPublish`.
* Ensure that  `UpdateCacheOnPublish` will be executed before Umbraco's `ContentIndexingNotificationHandler` by re-ordering them in the DI-container during registration.

I've performed some testing and can confirm that UpdateCacheOnPublish will run to complete before the `ContentIndexingNotificationHandler` starts the re-indexing and fires the `AddFullTextItemsToIndex.IndexProviderTransformingIndexValues()`-method in a background thread.
