### PR TITLE
Added logging for HttpPageRenderer

### DIFF
--- a/src/Our.Umbraco.FullTextSearch/Rendering/HttpPageRenderer.cs
+++ b/src/Our.Umbraco.FullTextSearch/Rendering/HttpPageRenderer.cs
@@ -41,6 +41,10 @@ public class HttpPageRenderer : IPageRenderer
 
             var httpClient = _httpClientFactory.CreateClient(FullTextSearchConstants.HttpClientFactoryNamedClientName);
             httpClient.DefaultRequestHeaders.Add(FullTextSearchConstants.HttpClientRequestHeaderName, _options.RenderingActiveKey);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("FullTextSearch: Processing node {NodeId}, fetching {Url}", publishedContent.Id, publishedPageUrl);
+
             var result = await httpClient.GetAsync(publishedPageUrl);
 
             string fullHtml = string.Empty;
@@ -50,13 +54,18 @@ public class HttpPageRenderer : IPageRenderer
             {
                 fullHtml = await result.Content.ReadAsStringAsync();
             }
+            else if(_logger.IsEnabled(LogLevel.Debug))
+            {
+                string pageContent = await result.Content.ReadAsStringAsync();
+                _logger.LogDebug("FullTextSearch: Status {HttpStatus} when rendering node {NodeId}. Content: {PageContent}", result.StatusCode, publishedContent.Id, pageContent);
+            }
 
             return fullHtml;
 
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Error in http-request for full text indexing of page {nodeId}, tried to fetch {url}", publishedContent.Id, publishedPageUrl);
+            _logger.LogError(e, "Error in http-request for full text indexing of page {NodeId}, tried to fetch {Url}", publishedContent.Id, publishedPageUrl);
         }
 
         return string.Empty;


### PR DESCRIPTION
Hi!

This PR referenced this issue #111, to add more logging in the `HttpPageRenderer`. Used LogLevel `Debug` and adjusted parameter naming to be PascalCase as this is used trough out the code base in other places.

There are other places (around 25) in the code base where `_logger.IsEnabled()` is not used. I would maybe call this a "micro-optimization" in this context as it's only executed when editors work in the backoffice. To keep the PR small and concise I decided not to touch the other places.