### PR TITLE
Do not fill SQL cache from Subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full Text Search can be installed via NuGet
 |1.x.x|8.1.x - 8.x.x|[v1.x Developers Guide](docs/developers-guide-v1.md)|
 |2.x.x|9.0.0 - 9.x.x|[v2.x Developers Guide](docs/developers-guide-v2.md)|
 |3.x.x|10.0.0 - 12.x.x|[v2/3 Developers Guide](docs/developers-guide-v2.md)|
-|**4.x.x**|10.0.0 - 12.x.x|[v4.x Developers Guide](docs/developers-guide-v4.md)|
+|**4.x.x**|10.0.0 - 13.x.x|[v4.x Developers Guide](docs/developers-guide-v4.md)|
 
 Only the latest minor is actively maintained.
 

--- a/src/Our.Umbraco.FullTextSearch/Interfaces/ISearch.cs
+++ b/src/Our.Umbraco.FullTextSearch/Interfaces/ISearch.cs
@@ -1,4 +1,5 @@
-﻿using Our.Umbraco.FullTextSearch.Models;
+﻿using Examine.Search;
+using Our.Umbraco.FullTextSearch.Models;
 using System.Collections.Generic;
 
 namespace Our.Umbraco.FullTextSearch.Interfaces
@@ -27,6 +28,8 @@ namespace Our.Umbraco.FullTextSearch.Interfaces
         string CustomQuery { get; set; }
         string Searcher { get; set; }
         string Index { get; set; }
+        SortableField[] OrderByFields { get; set; }
+        OrderDirection OrderDirection { get; set; }
 
         Search SetIndex(string index);
         Search SetSearcher(string searcher);

--- a/src/Our.Umbraco.FullTextSearch/Interfaces/ISearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Interfaces/ISearchService.cs
@@ -2,6 +2,7 @@
 {
     public interface ISearchService
     {
+        string GetLuceneQuery(ISearch search);
         IFullTextSearchResult Search(ISearch search, int currentPage);
     }
 }

--- a/src/Our.Umbraco.FullTextSearch/Models/OrderDirection.cs
+++ b/src/Our.Umbraco.FullTextSearch/Models/OrderDirection.cs
@@ -1,0 +1,7 @@
+﻿namespace Our.Umbraco.FullTextSearch.Models;
+
+public enum OrderDirection
+{
+    Ascending,
+    Descending
+}

--- a/src/Our.Umbraco.FullTextSearch/Models/Search.cs
+++ b/src/Our.Umbraco.FullTextSearch/Models/Search.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.QueryParsers.Classic;
+﻿using Examine.Search;
+using Lucene.Net.QueryParsers.Classic;
 using Our.Umbraco.FullTextSearch.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,6 +53,9 @@ namespace Our.Umbraco.FullTextSearch.Models
         public ICollection<string> SearchTermQuoted => new List<string> { '"' + QueryParser.Escape(SearchTerm) + '"' };
 
         public ICollection<string> SearchTermSplit => new List<string> { QueryParser.Escape(SearchTerm) };
+
+        public SortableField[] OrderByFields { get; set; }
+        public OrderDirection OrderDirection { get; set; } = OrderDirection.Descending;
 
         public Search SetSearchType(SearchType searchType)
         {
@@ -322,6 +326,13 @@ namespace Our.Umbraco.FullTextSearch.Models
         public Search SetCustomQuery(string customQuery)
         {
             CustomQuery = customQuery;
+            return this;
+        }
+
+        public Search OrderBy(SortableField[] orderBy, OrderDirection direction = OrderDirection.Ascending)
+        {
+            OrderByFields = orderBy;
+            OrderDirection = direction;
             return this;
         }
     }

--- a/src/Our.Umbraco.FullTextSearch/NotificationHandlers/UpdateCacheOnPublish.cs
+++ b/src/Our.Umbraco.FullTextSearch/NotificationHandlers/UpdateCacheOnPublish.cs
@@ -25,13 +25,15 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
         private IExamineManager _examineManager;
         private ICacheService _cacheService;
         private IContentService _contentService;
+        private readonly IServerRoleAccessor _serverRoleAccessor;
 
         public UpdateCacheOnPublish(
             IOptions<FullTextSearchOptions> options,
             ILogger<UpdateCacheOnPublish> logger,
             IExamineManager examineManager,
             ICacheService cacheService,
-            IContentService contentService
+            IContentService contentService,
+            IServerRoleAccessor serverRoleAccessor
             )
         {
             _options = options.Value;
@@ -39,13 +41,14 @@ namespace Our.Umbraco.FullTextSearch.NotificationHandlers
             _examineManager = examineManager;
             _cacheService = cacheService;
             _contentService = contentService;
-
+            _serverRoleAccessor = serverRoleAccessor;
         }
 
         public void Handle(ContentCacheRefresherNotification notification)
         {
         
-            if (notification.MessageType != MessageType.RefreshByPayload)
+            if (notification.MessageType != MessageType.RefreshByPayload ||
+                _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
                 return;
 
             if (!_options.Enabled)

--- a/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
@@ -189,7 +189,25 @@ namespace Our.Umbraco.FullTextSearch.Services
             if (searcher != null)
             {
                 _logger.LogDebug("Trying to search for {query}", query.ToString());
-                return searcher.CreateQuery().NativeQuery(query.ToString()).Execute(new Examine.Search.QueryOptions(_search.PageLength * (_currentPage - 1), _search.PageLength));
+
+                var searchQuery = searcher.CreateQuery().NativeQuery(query.ToString());
+                var queryOptions = new Examine.Search.QueryOptions(_search.PageLength * (_currentPage - 1), _search.PageLength);
+
+                if (_search.OrderByFields?.Length > 0)
+                {
+                    if (_search.OrderDirection is OrderDirection.Descending)
+                    {
+                        return searchQuery.OrderByDescending(_search.OrderByFields).Execute(queryOptions);
+                    }
+                    else
+                    {
+                        return searchQuery.OrderBy(_search.OrderByFields).Execute(queryOptions);
+                    }
+                }
+                else
+                {
+                    return searchQuery.Execute(queryOptions);
+                }
             }
 
             return null;

--- a/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
+++ b/src/Our.Umbraco.FullTextSearch/Services/SearchService.cs
@@ -88,6 +88,7 @@ namespace Our.Umbraco.FullTextSearch.Services
 
             if (_search.SearchTerm.IsNullOrWhiteSpace() == false)
             {
+                query.Append("(");
                 switch (_search.SearchType)
                 {
                     case SearchType.MultiRelevance:
@@ -124,6 +125,7 @@ namespace Our.Umbraco.FullTextSearch.Services
                         query.Append(QueryAllPropertiesAnd(_search.SearchTermSplit, 1.0));
                         break;
                 }
+                query.Append(")");
                 queryParts.Add(query.ToString());
             }
 
@@ -131,7 +133,7 @@ namespace Our.Umbraco.FullTextSearch.Services
             {
                 var rootNodeGroup = string.Join(" OR ", _search.RootNodeIds.Select(x =>
                     $"{_options.FullTextPathField}:{x}"));
-                queryParts.Add(rootNodeGroup);
+                queryParts.Add($"({rootNodeGroup})");
             }
 
             var allowedContentTypes = _search.AllowedContentTypes.Where(t => !string.IsNullOrWhiteSpace(t)).ToList();
@@ -139,7 +141,7 @@ namespace Our.Umbraco.FullTextSearch.Services
             {
                 var contentTypeGroup = string.Join(" OR ", allowedContentTypes.Select(x =>
                     $"__NodeTypeAlias:{x}"));
-                queryParts.Add(contentTypeGroup);
+                queryParts.Add($"({contentTypeGroup})");
             }
 
 
@@ -186,7 +188,7 @@ namespace Our.Umbraco.FullTextSearch.Services
             }
 
             query.Clear();
-            query.Append(string.Join(" AND ", queryParts.Select(x => $"({x})")));
+            query.Append(string.Join(" AND ", queryParts));
 
             if (searcher != null)
             {


### PR DESCRIPTION
I've sent the details through discord but short summary.

https://github.com/umbraco/Umbraco-CMS/issues/14195
Had a project go live with this package which had a lot of the lock issues from the link above.
Loadbalanced setup, gets worse with more frontend scaling/instances.
Deepdiving on SQL which showed me the Write lock was being blocked by a sleeping session/transaction on the database coming from my frontend application (maybe a scope .Complete() issue in code?).

This seems to be overkill anyway since the CM should fill this table?
Testing this change on production tonight but dev/acc simulations showed no more lock timeouts.